### PR TITLE
Allow HWC_NATIVE_MODULES to specify multiple paths

### DIFF
--- a/hwcconfig/application_host_config.go
+++ b/hwcconfig/application_host_config.go
@@ -53,8 +53,7 @@ func (c *HwcConfig) generateApplicationHostConfig() error {
 
 	var modulesConf []map[string]string
 
-	imageDirectory := os.Getenv("HWC_NATIVE_MODULES")
-	if imageDirectory != "" {
+	for _, imageDirectory := range filepath.SplitList(os.Getenv("HWC_NATIVE_MODULES")) {
 
 		directoryContents, err := ioutil.ReadDir(imageDirectory)
 		if err != nil {


### PR DESCRIPTION
We have a use case where an extension buildpack wants to add a native module that includes an agent. It appears that this is possible using the `HWC_NATIVE_MODULES` environment variable, but that it can only be used to specify a single path. This PR converts the environment variable into a path list and makes it possible to specify multiple locations to load modules from.