### PR TITLE
Adding ability to override bind address from the default wild card

### DIFF
--- a/hwcconfig/application_host_config.go
+++ b/hwcconfig/application_host_config.go
@@ -239,7 +239,7 @@ const applicationHostConfigTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         </application>
         {{ end }}
         <bindings>
-          <binding protocol="http" bindingInformation="*:{{.Config.Port}}:" />
+          <binding protocol="http" bindingInformation="{{.Config.BindAddress}}:{{.Config.Port}}:" />
         </bindings>
       </site>
     </sites>

--- a/hwcconfig/hwcconfig.go
+++ b/hwcconfig/hwcconfig.go
@@ -64,10 +64,12 @@ func New(port int, rootPath, tmpPath, contextPath, uuid string) (error, *HwcConf
 	config.AspnetConfigPath = filepath.Join(configPath, "Aspnet.config")
 	config.WebConfigPath = filepath.Join(configPath, "Web.config")
 
-	if os.Getenv("BIND_ADDRESS") == "" {
-		config.BindAddress = "*"
+	bindAddress, exists := os.LookupEnv("HWC_BIND_ADDRESS")
+
+	if exists {
+		config.BindAddress = bindAddress
 	} else {
-		config.BindAddress = os.Getenv("BIND_ADDRESS")
+		config.BindAddress = "*"
 	}
 
 	err = config.generateApplicationHostConfig()

--- a/hwcconfig/hwcconfig.go
+++ b/hwcconfig/hwcconfig.go
@@ -12,6 +12,7 @@ type HwcConfig struct {
 	TempDirectory                 string
 	IISCompressedFilesDirectory   string
 	ASPCompiledTemplatesDirectory string
+	BindAddress                   string
 
 	Applications              []*HwcApplication
 	AspnetConfigPath          string
@@ -62,6 +63,12 @@ func New(port int, rootPath, tmpPath, contextPath, uuid string) (error, *HwcConf
 	config.ApplicationHostConfigPath = filepath.Join(configPath, "ApplicationHost.config")
 	config.AspnetConfigPath = filepath.Join(configPath, "Aspnet.config")
 	config.WebConfigPath = filepath.Join(configPath, "Web.config")
+
+	if os.Getenv("BIND_ADDRESS") == "" {
+		config.BindAddress = "*"
+	} else {
+		config.BindAddress = os.Getenv("BIND_ADDRESS")
+	}
 
 	err = config.generateApplicationHostConfig()
 	if err != nil {


### PR DESCRIPTION
Developers without admin access are unable to run hwc Windows does not seem to allow non admin users to bind to a wild card Setting BIND_ADDRESS="127.0.0.1" works as a non admin user